### PR TITLE
Fix Arch install command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ wget -qO- https://git.io/papirus-icon-theme-install | sh
 #### Arch-Based
 
 ```
-yay -S awesome rofi picom i3lock-fancy xclip ttf-roboto polkit-gnome materia-theme lxappearance flameshot pnmixer network-manager-applet xfce4-power-manager qt5-styleplugins -y
-wget -qO- https://git.io/papirus-icon-theme-install | sh
+yay -S awesome rofi picom i3lock-fancy xclip ttf-roboto polkit-gnome materia-theme lxappearance flameshot pnmixer network-manager-applet xfce4-power-manager qt5-styleplugins papirus-icon-theme -y
 ```
 
 #### Program list


### PR DESCRIPTION
Papirus icon theme can be installed directly form repository and command for wget-ing it is removed. Package can be found here:
```sh
[community/papirus-icon-theme](https://archlinux.org/packages/community/any/papirus-icon-theme/)
```